### PR TITLE
Use user.avatarUrl instead of constructing it from user.id

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -99,7 +99,7 @@
               <td>{{user.rank}}.</td>
               <td><a href="https://github.com/{{user.login}}">{{user.login}}</a> ({{user.name}})</td>
               <td>{{user.contributions}}</td>
-              <td><img src="https://avatars3.githubusercontent.com/u/{{user.id}}?v=3&s=40" width="40" height="40" /></td>
+              <td><img src="{{user.avatarUrl}}" width="40" height="40" /></td>
             </tr>
           {% endfor %}
           </table>


### PR DESCRIPTION
I think putting a size restriction on the image should be done on the [data fetching side](https://github.com/lauripiispanen/most-active-github-users-counter/blob/master/github/github.go#L91) (with a [`size` argument](https://developer.github.com/v4/object/user/#avatarurl)), but it’s easy to add `&s=80` back, if you want.